### PR TITLE
Fix dashboards parsing for Graylog 3.2.2+

### DIFF
--- a/graylog/datasource/dashboard/data_source_test.go
+++ b/graylog/datasource/dashboard/data_source_test.go
@@ -81,6 +81,87 @@ data "graylog_dashboard" "test" {
 	})
 }
 
+// Graylog 3.2.2+
+func TestAccDashboard2(t *testing.T) {
+	if err := testutil.SetEnv(); err != nil {
+		t.Fatal(err)
+	}
+
+	getRoute := flute.Route{
+		Name: "get dashboards",
+		Matcher: flute.Matcher{
+			Method: "GET",
+		},
+		Tester: flute.Tester{
+			Path:         "/api/dashboards",
+			PartOfHeader: testutil.Header(),
+		},
+		Response: flute.Response{
+			Response: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 200,
+					Body: ioutil.NopCloser(strings.NewReader(`{
+  "total": 2,
+  "views": [
+    {
+      "id": "5ea8315b2ab79c00129dcba2",
+      "type": "DASHBOARD",
+      "title": "test",
+      "summary": "",
+      "description": "test description",
+      "search_id": "5ee8a8cd9f1165f8b3b7ffff",
+      "properties": [],
+      "requires": {},
+      "state": {
+        "e5dacef4-1d3d-44e6-8309-8d2cbcffffff": {
+          "selected_fields": null,
+          "static_message_list_id": null,
+          "titles": {},
+          "widgets": [],
+          "widget_mapping": {},
+          "positions": {},
+          "formatting": {
+            "highlighting": []
+          },
+          "display_mode_settings": {
+            "positions": {}
+          }
+        }
+      },
+      "owner": "admin",
+      "created_at": "2020-06-16T11:11:09.407Z"
+    }
+  ]
+}`)),
+				}, nil
+			},
+		},
+	}
+
+	readStep := resource.TestStep{
+		ResourceName: "data.graylog_dashboard.test",
+		PreConfig: func() {
+			testutil.SetHTTPClient(t, getRoute)
+		},
+		Config: `
+data "graylog_dashboard" "test" {
+  title = "test"
+}
+`,
+		Check: resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr("data.graylog_dashboard.test", "title", "test"),
+			resource.TestCheckResourceAttr("data.graylog_dashboard.test", "description", "test description"),
+		),
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers: testutil.SingleDataSourceProviders("graylog_dashboard", DataSource()),
+		Steps: []resource.TestStep{
+			readStep,
+		},
+	})
+}
+
 func TestAccDashboard_ByDashboardID(t *testing.T) {
 	if err := testutil.SetEnv(); err != nil {
 		t.Fatal(err)

--- a/graylog/datasource/dashboard/data_source_test.go
+++ b/graylog/datasource/dashboard/data_source_test.go
@@ -101,7 +101,7 @@ func TestAccDashboard2(t *testing.T) {
 				return &http.Response{
 					StatusCode: 200,
 					Body: ioutil.NopCloser(strings.NewReader(`{
-  "total": 2,
+  "total": 1,
   "views": [
     {
       "id": "5ea8315b2ab79c00129dcba2",

--- a/graylog/datasource/dashboard/read.go
+++ b/graylog/datasource/dashboard/read.go
@@ -34,7 +34,12 @@ func read(d *schema.ResourceData, m interface{}) error {
 		}
 		cnt := 0
 		var data map[string]interface{}
-		for _, a := range dashboards["dashboards"].([]interface{}) {
+		key := "dashboards"
+		if dashboards[key] == nil {
+			// Graylog 3.2.2+
+			key = "views"
+		}
+		for _, a := range dashboards[key].([]interface{}) {
 			dashboard := a.(map[string]interface{})
 			if dashboard["title"].(string) == title {
 				data = dashboard


### PR DESCRIPTION
Some time ago Graylog started migration of entity Dashboard to a View - https://github.com/Graylog2/graylog2-server/pull/6924 and this introduced some minor incompatibilities, one of them is returning results of API call `GET /dashboards`:
before:
```
{
  "total": 2,
  "dashboards": [
    {
      "creator_user_id": "admin",
      "description": "zoo",
      "created_at": "2020-04-28T13:36:27.559Z",
      "positions": {},
      "id": "5ea8315b2ab79c00129dcba2",
      "title": "zoo",
      "widgets": []
    },
    {
      "creator_user_id": "admin",
      "description": "test description",
      "created_at": "2020-04-28T13:36:27.559Z",
      "positions": {},
      "id": "5ea8315b2ab79c00129dcba2",
      "title": "test",
      "widgets": []
    }
  ]
}
```

after:
```
{
  "total": 1,
  "views": [
    {
      "id": "5ea8315b2ab79c00129dcba2",
      "type": "DASHBOARD",
      "title": "test",
      "summary": "",
      "description": "test description",
      "search_id": "5ee8a8cd9f1165f8b3b7ffff",
      "properties": [],
      "requires": {},
      "state": {
        "e5dacef4-1d3d-44e6-8309-8d2cbcffffff": {
          "selected_fields": null,
          "static_message_list_id": null,
          "titles": {},
          "widgets": [],
          "widget_mapping": {},
          "positions": {},
          "formatting": {
            "highlighting": []
          },
          "display_mode_settings": {
            "positions": {}
          }
        }
      },
      "owner": "admin",
      "created_at": "2020-06-16T11:11:09.407Z"
    }
  ]
}
```

Trying to import existing dashboards with new Graylog server before the terraform provider patch:
```
data "graylog_dashboard" "test" {
  title = "test"
}

panic: interface conversion: interface {} is nil, not []interface {}                                                           
[DEBUG] plugin.terraform-provider-graylog: goroutine 30 [running]:                                
[DEBUG] plugin.terraform-provider-graylog: github.com/terraform-provider-graylog/terraform-provider-graylog/graylog/datasource/dashboard.read(0xc0003af500, 0xf4e260, 0xc0001f0370, 0xc0003af500, 0x0)     
```

this change tries to parse both variants.