### PR TITLE
docs: update YAML Frontmatter

### DIFF
--- a/docs/data-sources/dashboard.md
+++ b/docs/data-sources/dashboard.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_dashboard"
----
-
 # graylog_dashboard Data Source
 
 * [Source Code](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/graylog/datasource/dashboard/resource.go)

--- a/docs/data-sources/index_set.md
+++ b/docs/data-sources/index_set.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_index_set"
----
-
 # graylog_index_set Data Source
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/index_set.tf)

--- a/docs/data-sources/sidecar.md
+++ b/docs/data-sources/sidecar.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_sidecar"
----
-
 # graylog_sidecar Data Source
 
 * [Source Code](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/graylog/datasource/sidecar/data_source.go)

--- a/docs/data-sources/stream.md
+++ b/docs/data-sources/stream.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_stream"
----
-
 # graylog_stream Data Source
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/stream.tf)

--- a/docs/guides/json-string-attribute.md
+++ b/docs/guides/json-string-attribute.md
@@ -1,3 +1,7 @@
+---
+page_title: "JSON string attributes"
+---
+
 # JSON string attributes
 
 In this provider, the type of some attributes is not complex type but JSON string.

--- a/docs/guides/migration-detail.md
+++ b/docs/guides/migration-detail.md
@@ -1,5 +1,6 @@
 ---
 page_title: "Migration Guide Detail"
+subcategory: "Migration from go-graylog"
 ---
 
 # Migration Guide Detail

--- a/docs/guides/migration-guide.md
+++ b/docs/guides/migration-guide.md
@@ -1,5 +1,6 @@
 ---
 page_title: "Migration Guide"
+subcategory: "Migration from go-graylog"
 ---
 
 # Migration Guide

--- a/docs/guides/migration-what-is-changed.md
+++ b/docs/guides/migration-what-is-changed.md
@@ -1,5 +1,6 @@
 ---
 page_title: "Changes from go-graylog"
+subcategory: "Migration from go-graylog"
 ---
 
 # Changes from go-graylog

--- a/docs/guides/migration/detail.md
+++ b/docs/guides/migration/detail.md
@@ -1,3 +1,7 @@
+---
+page_title: "Migration Guide Detail"
+---
+
 # Migration Guide Detail
 
 ## No changes

--- a/docs/guides/migration/guide.md
+++ b/docs/guides/migration/guide.md
@@ -1,3 +1,7 @@
+---
+page_title: "Migration Guide"
+---
+
 # Migration Guide
 
 In this page, we describe the overview of how to migrate Terraform provider from [go-graylog v11.3.0](https://github.com/suzuki-shunsuke/go-graylog/tree/v11.3.0) to this provider.  

--- a/docs/guides/migration/what-is-changed.md
+++ b/docs/guides/migration/what-is-changed.md
@@ -1,3 +1,7 @@
+---
+page_title: "Changes from go-graylog"
+---
+
 # Changes from go-graylog
 
 In this page, we describe what is changed from [go-graylog](https://github.com/suzuki-shunsuke/go-graylog) to this provider.

--- a/docs/resources/alarm_callback.md
+++ b/docs/resources/alarm_callback.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_alarm_callback"
----
-
 # Resource: graylog_alarm_callback
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/alarm_callback.tf)

--- a/docs/resources/alert_condition.md
+++ b/docs/resources/alert_condition.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_alert_condition"
----
-
 # Resource: graylog_alert_condition
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/alert_condition.tf)

--- a/docs/resources/dashboard.md
+++ b/docs/resources/dashboard.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_dashboard"
----
-
 # Resource: graylog_dashboard
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/dashboard.tf)

--- a/docs/resources/dashboard_widget.md
+++ b/docs/resources/dashboard_widget.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_dashboard_widget"
----
-
 # Resource: graylog_dashboard_widget
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/dashboard.tf)

--- a/docs/resources/dashboard_widget_positions.md
+++ b/docs/resources/dashboard_widget_positions.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_dashboard_widget_positions"
----
-
 # Resource: graylog_dashboard_widget_positions
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/dashboard.tf)

--- a/docs/resources/event_definition.md
+++ b/docs/resources/event_definition.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_event_definition"
----
-
 # Resource: graylog_event_definition
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/event_definition.tf)

--- a/docs/resources/event_notification.md
+++ b/docs/resources/event_notification.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_event_notification"
----
-
 # Resource: graylog_event_notification
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/event_notification.tf)

--- a/docs/resources/extractor.md
+++ b/docs/resources/extractor.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_extractor"
----
-
 # Resource: graylog_extractor
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/extractor.tf)

--- a/docs/resources/grok_pattern.md
+++ b/docs/resources/grok_pattern.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_grok_pattern"
----
-
 # Resource: graylog_grok_pattern
 
 * [Source Code](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/graylog/resource/system/grok/resource.go)

--- a/docs/resources/index_set.md
+++ b/docs/resources/index_set.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_index_set"
----
-
 # Resource: graylog_index_set
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/index_set.tf)

--- a/docs/resources/input.md
+++ b/docs/resources/input.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_input"
----
-
 # Resource: graylog_input
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/input.tf)

--- a/docs/resources/input_static_fields.md
+++ b/docs/resources/input_static_fields.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_input_static_fields"
----
-
 # Resource: graylog_input_static_fields
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/input.tf)

--- a/docs/resources/ldap_setting.md
+++ b/docs/resources/ldap_setting.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_ldap_setting"
----
-
 # Resource: graylog_ldap_setting
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/ldap_setting.tf)

--- a/docs/resources/output.md
+++ b/docs/resources/output.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_output"
----
-
 # Resource: graylog_output
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/output.tf)

--- a/docs/resources/pipeline.md
+++ b/docs/resources/pipeline.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_pipeline"
----
-
 # Resource: graylog_pipeline
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/pipeline.tf)

--- a/docs/resources/pipeline_connection.md
+++ b/docs/resources/pipeline_connection.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_pipeline_connection"
----
-
 # Resource: graylog_pipeline_connection
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/pipeline.tf)

--- a/docs/resources/pipeline_rule.md
+++ b/docs/resources/pipeline_rule.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_pipeline_rule"
----
-
 # Resource: graylog_pipeline_rule
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/pipeline.tf)

--- a/docs/resources/role.md
+++ b/docs/resources/role.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_role"
----
-
 # Resource: graylog_role
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/role.tf)

--- a/docs/resources/sidecar_collector.md
+++ b/docs/resources/sidecar_collector.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_sidecar_collector"
----
-
 # Resource: graylog_sidecar_collector
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/sidecar_collector.tf)

--- a/docs/resources/sidecar_configuration.md
+++ b/docs/resources/sidecar_configuration.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_sidecar_configuration"
----
-
 # Resource: graylog_sidecar_configuration
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/sidecar_configuration.tf)

--- a/docs/resources/sidecars.md
+++ b/docs/resources/sidecars.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_sidecars"
----
-
 # Resource: graylog_sidecars
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/sidecar.tf)

--- a/docs/resources/stream.md
+++ b/docs/resources/stream.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_stream"
----
-
 # Resource: graylog_stream
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/stream.tf)

--- a/docs/resources/stream_output.md
+++ b/docs/resources/stream_output.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_stream_output"
----
-
 # Resource: graylog_stream_output
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/stream_output.tf)

--- a/docs/resources/stream_rule.md
+++ b/docs/resources/stream_rule.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_stream_rule"
----
-
 # Resource: graylog_stream_rule
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/stream_rule.tf)

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -1,7 +1,3 @@
----
-page_title: "Graylog: graylog_user"
----
-
 # Resource: graylog_user
 
 * [Example](https://github.com/terraform-provider-graylog/terraform-provider-graylog/blob/master/examples/v0.12/user.tf)


### PR DESCRIPTION
#38 

Remove unneeded YAML Frontmatter of resource and data sources.

https://www.terraform.io/docs/registry/providers/docs.html#yaml-frontmatter

> Frontmatter can be omitted for resources and data sources that don't require a subcategory.

Set the subcategory "Migration from go-graylog" to migration guides.

https://www.terraform.io/docs/registry/providers/docs.html#guides-subcategories