### PR TITLE
Correct syntax for null condition

### DIFF
--- a/examples/v0.12/event_definition.tf
+++ b/examples/v0.12/event_definition.tf
@@ -15,7 +15,9 @@ resource "graylog_event_definition" "test" {
     execute_every_ms = 60000
     group_by         = []
     series           = []
-    conditions       = null
+    conditions       = {
+      expression = null
+    }
   })
 
   field_spec = jsonencode({


### PR DESCRIPTION
If using the first example for a null condition, this causes an error when accessing to the alert definition summary on UI: "Cannot read property 'expression' of null".